### PR TITLE
Add OpenAI o3 model option

### DIFF
--- a/services/manualService.js
+++ b/services/manualService.js
@@ -72,7 +72,7 @@ class ManualService {
                 content: content
             }
             ],
-            ...(model !== 'o3-mini' && { temperature: 0.3 }),
+            ...(model !== 'o3-mini' && model !== 'o3' && { temperature: 0.3 }),
         });
     
         let jsonContent = response.choices[0].message.content;
@@ -168,7 +168,7 @@ class ManualService {
                     content: content
                 }
                 ],
-                ...(model !== 'o3-mini' && { temperature: 0.3 }),
+                ...(model !== 'o3-mini' && model !== 'o3' && { temperature: 0.3 }),
             });
         
             let jsonContent = response.choices[0].message.content;

--- a/services/openaiService.js
+++ b/services/openaiService.js
@@ -186,7 +186,7 @@ class OpenAIService {
             content: truncatedContent
           }
         ],
-        ...(model !== 'o3-mini' && { temperature: 0.3 }),
+        ...(model !== 'o3-mini' && model !== 'o3' && { temperature: 0.3 }),
       });
 
       if (!response?.choices?.[0]?.message?.content) {
@@ -310,7 +310,7 @@ class OpenAIService {
             content: truncatedContent
           }
         ],
-        ...(model !== 'o3-mini' && { temperature: 0.3 }),
+        ...(model !== 'o3-mini' && model !== 'o3' && { temperature: 0.3 }),
       });
 
       // Handle response

--- a/views/settings.ejs
+++ b/views/settings.ejs
@@ -300,6 +300,7 @@
                                                 class="w-full px-3 py-2 border border-gray-300 rounded-lg shadow-sm focus:ring-2 focus:ring-blue-500 focus:border-blue-500">
                                             <option value="gpt-3.5-turbo-0125" <%= config.OPENAI_MODEL === 'gpt-3.5-turbo-0125' ? 'selected' : '' %>>GPT-3.5 Turbo</option>
                                             <option value="gpt-4o" <%= config.OPENAI_MODEL === 'gpt-4o' ? 'selected' : '' %>>GPT-4o</option>
+                                            <option value="o3" <%= config.OPENAI_MODEL === 'o3' ? 'selected' : '' %>>o3</option>
                                             <option value="o3-mini" <%= config.OPENAI_MODEL === 'o3-mini' ? 'selected' : '' %>>o3-mini</option>
                                             <option value="gpt-4o-mini" <%= config.OPENAI_MODEL === 'gpt-4o-mini' ? 'selected' : '' %>>GPT-4o-mini (Best value)</option>
                                         </select>

--- a/views/setup.ejs
+++ b/views/setup.ejs
@@ -235,6 +235,7 @@
                                                     class="modern-input">
                                                 <option value="gpt-3.5-turbo-0125" <%= config.OPENAI_MODEL === 'gpt-3.5-turbo-0125' ? 'selected' : '' %>>GPT-3.5 Turbo</option>
                                                 <option value="gpt-4o" <%= config.OPENAI_MODEL === 'gpt-4o' ? 'selected' : '' %>>GPT-4o</option>
+                                                <option value="o3" <%= config.OPENAI_MODEL === 'o3' ? 'selected' : '' %>>o3</option>
                                                 <option value="o3-mini" <%= config.OPENAI_MODEL === 'o3-mini' ? 'selected' : '' %>>o3-mini</option>
                                                 <option value="gpt-4o-mini" <%= config.OPENAI_MODEL === 'gpt-4o-mini' ? 'selected' : '' %>>GPT-4o-mini (Best value)</option>
                                             </select>


### PR DESCRIPTION
## Summary
- support new `o3` model in OpenAI services
- show `o3` model in setup and settings pages

## Testing
- `npm test` *(fails: nodemon not found)*

------
https://chatgpt.com/codex/tasks/task_e_6863c0aa8410832eadb40fca07985e79